### PR TITLE
Upgraded to major version 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.0.0] - ?
+## Changed
+ - Deprecated com.joyent.http.signature.google.httpclient.RequestHttpSigner.signURI.
+   This method is now being provided directly in the Manta SDK.
+ - Upgraded to jnagmp 2.0.0.
+## Added
+ - Added HttpSignatureRequestInterceptor as an addition method to perform authentication with Apache HTTP Client. 
+
 ## [2.2.2] - 2016-10-25
 ### Fixed
  - [Fixed locales aren't hardcoded to English](https://github.com/joyent/java-http-signature/issues/13) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.0.0] - ?
+## [3.0.0] - 2016-12-19
 ## Changed
  - Deprecated com.joyent.http.signature.google.httpclient.RequestHttpSigner.signURI.
    This method is now being provided directly in the Manta SDK.

--- a/apache-http-client/pom.xml
+++ b/apache-http-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>java-http-signature</artifactId>
         <groupId>com.joyent.http-signature</groupId>
-        <version>2.2.3-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apache-http-client-signature</artifactId>

--- a/apache-http-client/pom.xml
+++ b/apache-http-client/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <!-- Dependency versions -->
-        <dependency.http-signature-common.version>2.2.3-SNAPSHOT</dependency.http-signature-common.version>
+        <dependency.http-signature-common.version>3.0.0-SNAPSHOT</dependency.http-signature-common.version>
         <dependency.slfj.version>1.7.21</dependency.slfj.version>
         <dependency.logback.version>1.1.7</dependency.logback.version>
     </properties>

--- a/apache-http-client/src/main/java/com/joyent/http/signature/apache/httpclient/HttpSignatureAuthScheme.java
+++ b/apache-http-client/src/main/java/com/joyent/http/signature/apache/httpclient/HttpSignatureAuthScheme.java
@@ -47,7 +47,7 @@ public class HttpSignatureAuthScheme implements ContextAwareAuthScheme {
     /**
      * Thread local instance of {@link Signer}.
      */
-    private final ThreadLocal<Signer> signer;
+    private final ThreadLocalSigner signer;
 
     /**
      * Creates a new instance allowing for HTTP signing.
@@ -190,5 +190,9 @@ public class HttpSignatureAuthScheme implements ContextAwareAuthScheme {
         final Header authzHeader = new BasicHeader(HttpHeaders.AUTHORIZATION, authz);
 
         return authzHeader;
+    }
+
+    public ThreadLocalSigner getSigner() {
+        return signer;
     }
 }

--- a/apache-http-client/src/main/java/com/joyent/http/signature/apache/httpclient/HttpSignatureRequestInterceptor.java
+++ b/apache-http-client/src/main/java/com/joyent/http/signature/apache/httpclient/HttpSignatureRequestInterceptor.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 /**
  * Alternative to HTTP Client {@link org.apache.http.auth.AuthScheme} approach
  * that uses a {@link org.apache.http.HttpRequestInterceptor} to perform
- * HTTP signature authentication
+ * HTTP signature authentication.
  *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  * @since 3.0.0
@@ -24,7 +24,7 @@ public class HttpSignatureRequestInterceptor implements HttpRequestInterceptor {
     private final boolean authEnabled;
 
     /**
-     * Authentication scheme instance to use to create authentication header;
+     * Authentication scheme instance to use to create authentication header.
      */
     private final HttpSignatureAuthScheme authScheme;
 

--- a/apache-http-client/src/main/java/com/joyent/http/signature/apache/httpclient/HttpSignatureRequestInterceptor.java
+++ b/apache-http-client/src/main/java/com/joyent/http/signature/apache/httpclient/HttpSignatureRequestInterceptor.java
@@ -1,0 +1,62 @@
+package com.joyent.http.signature.apache.httpclient;
+
+import org.apache.http.Header;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.auth.Credentials;
+import org.apache.http.protocol.HttpContext;
+
+import java.io.IOException;
+
+/**
+ * Alternative to HTTP Client {@link org.apache.http.auth.AuthScheme} approach
+ * that uses a {@link org.apache.http.HttpRequestInterceptor} to perform
+ * HTTP signature authentication
+ *
+ * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
+ * @since 3.0.0
+ */
+public class HttpSignatureRequestInterceptor implements HttpRequestInterceptor {
+    /**
+     * Flag indicating that HTTP signature authentication is enabled.
+     */
+    private final boolean authEnabled;
+
+    /**
+     * Authentication scheme instance to use to create authentication header;
+     */
+    private final HttpSignatureAuthScheme authScheme;
+
+    /**
+     * Credentials of the user authenticating using HTTP signatures.
+     */
+    private final Credentials credentials;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param authScheme authentication scheme used to generate signature
+     * @param credentials credentials of user authenticating
+     * @param authEnabled flag indicating if authentication is enabled
+     */
+    public HttpSignatureRequestInterceptor(final HttpSignatureAuthScheme authScheme,
+                                           final Credentials credentials,
+                                           final boolean authEnabled) {
+        this.authScheme = authScheme;
+        this.credentials = credentials;
+        this.authEnabled = authEnabled;
+    }
+
+    @Override
+    public void process(final HttpRequest request, final HttpContext context)
+            throws HttpException, IOException {
+        if (!authEnabled) {
+            return;
+        }
+
+        final Header authorization = authScheme.authenticate(
+                this.credentials, request, context);
+        request.setHeader(authorization);
+    }
+}

--- a/apache-http-client/src/main/java/com/joyent/http/signature/apache/httpclient/package-info.java
+++ b/apache-http-client/src/main/java/com/joyent/http/signature/apache/httpclient/package-info.java
@@ -2,6 +2,14 @@
  * Package containing utility classes for using HTTP Signature with the
  * Apache HTTP Client.
  *
+ * There are two primary implementations an {@link org.apache.http.auth.AuthScheme}
+ * implementation implemented as {@link com.joyent.http.signature.apache.httpclient.HttpSignatureAuthScheme} and
+ * a {@link org.apache.http.HttpRequestInterceptor} implementation implemented
+ * as {@link com.joyent.http.signature.apache.httpclient.HttpSignatureRequestInterceptor}.
+ * Both classes are valid ways of implementing HTTP Signatures with the Apache
+ * Commons HTTP Client. Depending on your application one implementation may
+ * be better than another.
+ *
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  */
 package com.joyent.http.signature.apache.httpclient;

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <!-- Dependency versions -->
         <dependency.bouncycastle.version>1.55</dependency.bouncycastle.version>
-        <dependency.jnagmp.version>1.1.0</dependency.jnagmp.version>
+        <dependency.jnagmp.version>2.0.0</dependency.jnagmp.version>
     </properties>
 
     <dependencies>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>java-http-signature</artifactId>
         <groupId>com.joyent.http-signature</groupId>
-        <version>2.2.3-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>http-signature-common</artifactId>

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>java-http-signature</artifactId>
         <groupId>com.joyent.http-signature</groupId>
-        <version>2.2.3-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <!-- Dependency versions -->
-        <dependency.http-signature-common.version>2.2.3-SNAPSHOT</dependency.http-signature-common.version>
+        <dependency.http-signature-common.version>3.0.0-SNAPSHOT</dependency.http-signature-common.version>
         <dependency.google-http-client.version>1.22.0</dependency.google-http-client.version>
     </properties>
 

--- a/google-http-client/src/main/java/com/joyent/http/signature/google/httpclient/RequestHttpSigner.java
+++ b/google-http-client/src/main/java/com/joyent/http/signature/google/httpclient/RequestHttpSigner.java
@@ -131,6 +131,8 @@ public class RequestHttpSigner {
      * Signs an arbitrary URL using the Manta-compatible HTTP signature
      * method.
      *
+     * Deprecated: Use method provided inside the Java Manta SDK.
+     *
      * @param uri URI with no query pointing to a downloadable resource
      * @param method HTTP request method to be used in the signature
      * @param expires epoch time in seconds when the resource will no longer
@@ -138,6 +140,7 @@ public class RequestHttpSigner {
      * @return a signed version of the input URI
      * @throws IOException thrown when we can't sign or read char data
      */
+    @Deprecated
     public URI signURI(final URI uri, final String method, final long expires)
             throws IOException {
         Objects.requireNonNull(method, "Method must be present");

--- a/jaxrs-client/pom.xml
+++ b/jaxrs-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>java-http-signature</artifactId>
         <groupId>com.joyent.http-signature</groupId>
-        <version>2.2.3-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-client-signature</artifactId>

--- a/jaxrs-client/pom.xml
+++ b/jaxrs-client/pom.xml
@@ -14,7 +14,7 @@
         <!-- Dependency versions -->
         <dependency.arquillian.version>1.1.10.Final</dependency.arquillian.version>
         <dependency.arquillian-glassfish-embedded-3.1.version>1.0.0.Final</dependency.arquillian-glassfish-embedded-3.1.version>
-        <dependency.http-signature-common.version>2.2.3-SNAPSHOT</dependency.http-signature-common.version>
+        <dependency.http-signature-common.version>3.0.0-SNAPSHOT</dependency.http-signature-common.version>
         <dependency.javaee.version>7.0</dependency.javaee.version>
         <dependency.jax-rs-api.version>2.0.1</dependency.jax-rs-api.version>
         <dependency.jersey-client.version>2.23.2</dependency.jersey-client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.joyent.http-signature</groupId>
     <artifactId>java-http-signature</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>java-http-signature</name>


### PR DESCRIPTION
## Changed
 - Deprecated com.joyent.http.signature.google.httpclient.RequestHttpSigner.signURI.
   This method is now being provided directly in the Manta SDK.
 - Upgraded to jnagmp 2.0.0.
## Added
 - Added HttpSignatureRequestInterceptor as an addition method to perform authentication with Apache HTTP Client. 