### PR TITLE
restore jaxrs-client integration tests

### DIFF
--- a/jaxrs-client/pom.xml
+++ b/jaxrs-client/pom.xml
@@ -111,19 +111,19 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
-                        <configuration>
-                            <argLine>-Djava.awt.headless=true</argLine><!-- prevent the annoying ForkedBooter process from stealing window focus on Mac OSX -->
-                            <skip>${maven.integration.test.skip}</skip>
-                            <suiteXmlFiles>
-                                <suiteXmlFile>src/test/resources/testng-it.xml</suiteXmlFile>
-                            </suiteXmlFiles>
-                            <systemPropertyVariables>
-                                <derby.stream.error.file>${project.build.directory}/derby.log</derby.stream.error.file><!-- prevent embedded container from logging derby activity -->
-                                <java.util.logging.config.file>${project.build.testOutputDirectory}/logging.properties</java.util.logging.config.file><!-- prevent embedded container from being so verbose -->
-                            </systemPropertyVariables>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <argLine>-Djava.awt.headless=true</argLine><!-- prevent the annoying ForkedBooter process from stealing window focus on Mac OSX -->
+                    <skip>${maven.integration.test.skip}</skip>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng-it.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <systemPropertyVariables>
+                        <derby.stream.error.file>${project.build.directory}/derby.log</derby.stream.error.file><!-- prevent embedded container from logging derby activity -->
+                        <java.util.logging.config.file>${project.build.testOutputDirectory}/logging.properties</java.util.logging.config.file><!-- prevent embedded container from being so verbose -->
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
The `configuration` block was incorrectly nested inside an
`execution`.  This prevented the configuration from being used and
thus not tests ran.  As far as I can tell this dates back all the way
to 1772b4ceeaf38a9e2cf7ae1929d2fdd7fc22a2ec.