### PR TITLE
create JMH based microbenchmarks

### DIFF
--- a/apache-http-client/src/test/java/com/joyent/http/signature/apache/httpclient/HttpSignatureRequestInterceptorTest.java
+++ b/apache-http-client/src/test/java/com/joyent/http/signature/apache/httpclient/HttpSignatureRequestInterceptorTest.java
@@ -73,7 +73,7 @@ public class HttpSignatureRequestInterceptorTest {
 
         HttpContext context = new BasicHttpContext();
 
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < 5; i++) {
             interceptor.process(request, context);
             String signTime = request.getFirstHeader("x-http-signing-time-ns").getValue();
             System.out.printf("Time to sign: %s\n", signTime);

--- a/google-http-client/src/test/java/com/joyent/http/signature/google/httpclient/RequestHttpSignerTest.java
+++ b/google-http-client/src/test/java/com/joyent/http/signature/google/httpclient/RequestHttpSignerTest.java
@@ -96,7 +96,7 @@ public class RequestHttpSignerTest {
         HttpRequest request = factory.buildGetRequest(get);
 
         long running = 0L;
-        int iterations = 1000;
+        int iterations = 5;
 
         for (int i = 0; i < iterations; i++) {
             long start = System.currentTimeMillis();

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2015-2017, Joyent, Inc. All rights reserved.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>java-http-signature</artifactId>
+        <groupId>com.joyent.http-signature</groupId>
+        <version>3.0.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>microbench</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <!-- Dependency versions -->
+        <dependency.http-signature-common.version>3.0.3-SNAPSHOT</dependency.http-signature-common.version>
+        <dependency.jmh.version>1.17.5</dependency.jmh.version>
+        <uberjar.name>benchmarks</uberjar.name>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.joyent.http-signature</groupId>
+            <artifactId>http-signature-common</artifactId>
+            <version>${dependency.http-signature-common.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.joyent.http-signature</groupId>
+            <artifactId>http-signature-common</artifactId>
+            <version>${dependency.http-signature-common.version}</version>
+            <type>test-jar</type>
+            <!-- Need the test code to support the benchmarks, which
+                 are not "test" code to maven -->
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${dependency.jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${dependency.jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${uberjar.name}</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <!--
+                                        Shading signed JARs will fail without this.
+                                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                                    -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/microbench/src/main/java/com/joyent/http/signature/BenchmarkSigner.java
+++ b/microbench/src/main/java/com/joyent/http/signature/BenchmarkSigner.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2013-2017, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.http.signature;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.IOException;
+import java.security.KeyPair;
+import java.util.concurrent.TimeUnit;
+
+/* See http://openjdk.java.net/projects/code-tools/jmh/ for general
+ * information on JMH and running benchmarks.  In general one would
+ * "package" this module, and run `java -jar target/benchmark.jar`. */
+@State(Scope.Thread)
+public class BenchmarkSigner {
+    private String testKeyFingerprint;
+    private KeyPair keyPair;
+    private Signer signer;
+    private String verifyNow;
+    private String verifyHeader;
+
+    @Param({"vanilla", "native"})
+    private String signType;
+
+    @Setup
+    public void setup() throws IOException {
+        switch (signType) {
+        case "vanilla":
+            signer = new Signer(false);
+            break;
+        case "native":
+            signer = new Signer(true);
+            break;
+        default:
+            throw new IllegalArgumentException();
+        }
+        testKeyFingerprint = SignerTestUtil.testKeyFingerprint;
+        keyPair = SignerTestUtil.testKeyPair(signer);
+
+        verifyNow = signer.defaultSignDateAsString();
+        verifyHeader = signHeader(verifyNow);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public String signHeaderThroughput() {
+        String now = signer.defaultSignDateAsString();
+        return signHeader(now);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public String signHeaderLatency() {
+        String now = signer.defaultSignDateAsString();
+        return signHeader(now);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public boolean verifyHeaderThroughput() {
+        return verifyHeader(verifyNow, verifyHeader);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public boolean verifyHeaderLatency() {
+        return verifyHeader(verifyNow, verifyHeader);
+    }
+
+    private String signHeader(final String now) {
+        String authzHeader = signer.createAuthorizationHeader("bench", testKeyFingerprint, keyPair, now);
+        return authzHeader;
+    }
+
+    private boolean verifyHeader(final String ts, final String header) {
+        return signer.verifyAuthorizationHeader(keyPair, header, ts);
+
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,8 @@
         <module>google-http-client</module>
         <module>apache-http-client</module>
         <module>jaxrs-client</module>
-    </modules>
+        <module>microbench</module>
+  </modules>
 
     <scm>
         <connection>scm:git:git://github.com/joyent/java-http-signature.git</connection>
@@ -146,6 +147,7 @@
                     <skip>${checkstyle.skip}</skip>
                     <suppressionsLocation>suppressions.xml</suppressionsLocation>
                     <violationSeverity>warning</violationSeverity>
+                    <excludes>**/generated/**/*</excludes>
                 </configuration>
                 <executions>
                     <execution>

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -12,4 +12,5 @@
     <suppress checks="ImportControl" files="^.*Test\.java$" />
     <suppress checks="[a-zA-Z0-9]*" files="MantaNativeRSACoreEngine.java" />
     <suppress checks="Header" files="NativeRSABlindedEngine.java" />
+    <suppress checks="Javadoc.*" files="BenchmarkSigner.java" />
 </suppressions>


### PR DESCRIPTION
JMH is a tool for java microbenchmarks tries to mitigate most of the
obvious ways JVM can deceive naive approaches.  This will allow us to
compare signing algorithms, hashes, and providers to give better
recommendations.

Example results from a reasonable public cloud container:
 * SHA256withRSA: signHeaderLatency·p0.99 6676.480 us/op
 * SHA256withNativeRSA: signHeaderLatency·p0.99 1460.224 us/op

NOTE: There was some benchmark-esque behavior in some of the unit
tests.  The iterations there are toned down to avoid > 10k lines of
output