### PR TITLE
allow NSS via PKS#11 to be used for ECDSA singing

### DIFF
--- a/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
+++ b/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
@@ -7,12 +7,12 @@
  */
 package com.joyent.http.signature;
 
+import com.joyent.http.signature.crypto.NssBridgeKeyConverter;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMDecryptorProvider;
 import org.bouncycastle.openssl.PEMEncryptedKeyPair;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
-import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
 
 import java.io.BufferedReader;
@@ -41,8 +41,11 @@ public final class KeyPairLoader {
     /**
      * The key format converter to use when reading key pairs.
      */
-    private static final JcaPEMKeyConverter CONVERTER =
-        new JcaPEMKeyConverter().setProvider("BC");
+    private static final NssBridgeKeyConverter CONVERTER =
+        new NssBridgeKeyConverter();
+    {
+        CONVERTER.setProvider("BC");
+    }
 
     /**
      * Read KeyPair located at the specified path.

--- a/common/src/main/java/com/joyent/http/signature/Signer.java
+++ b/common/src/main/java/com/joyent/http/signature/Signer.java
@@ -393,7 +393,8 @@ public class Signer {
     public String toString() {
         final StringBuilder sb = new StringBuilder("Signer{");
         sb.append("signature=").append(signature);
-        sb.append("httpHeaderAlgorithme=").append(httpHeaderAlgorithm);
+        sb.append(",provider=").append(signature.getProvider().getName());
+        sb.append(",httpHeaderAlgorithm=").append(httpHeaderAlgorithm);
         sb.append('}');
         return sb.toString();
     }
@@ -544,7 +545,8 @@ public class Signer {
                     return new RsaHelper();
                 } else if (algorithm.equals("DSA")) {
                     return new DsaHelper();
-                } else if (algorithm.equals("ECDSA")) {
+                    // See NssBridgeKeyConverter on the two names
+                } else if (algorithm.equals("ECDSA") || algorithm.equals("EC")) {
                     return new EcdsaHelper();
                 } else {
                     throw new IllegalArgumentException("invalid signing algorithm: " + algorithm);

--- a/common/src/main/java/com/joyent/http/signature/crypto/NssBridgeKeyConverter.java
+++ b/common/src/main/java/com/joyent/http/signature/crypto/NssBridgeKeyConverter.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.http.signature.crypto;
+
+import org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.security.Provider;
+import java.security.Security;
+
+/**
+ * There is an unfortunate naming discrepancy between BouncyCastle and
+ * other security providers over the name of ECDSA.  BouncyCastle uses
+ * the string "ECDSA", while several standard library providers use
+ * the string "EC".  This means that regardless of the configured
+ * provider preferences, JcaPEMKeyConverter will always end up using
+ * the "BC" (BouncyCastle) provider for ECDSA.  This is generally
+ * benign because the same algorithms are implimented, and
+ * BouncyCastle is often faster.  However, it does prevent calling out
+ * to NSS via the PKCS#11 provider.  In the case of ECDSA,
+ * microbenchmarks demonstrate that NSS is significantly faster than
+ * BouncyCastle.
+ *
+ * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/guides/security/p11guide.html">PKCS#11 Reference Guide</a>
+ * @see <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS">Network Security Services</a>
+ */
+public class NssBridgeKeyConverter extends JcaPEMKeyConverter {
+
+    {
+        Provider[] providers = Security.getProviders();
+        try {
+            if (providers == null || providers.length == 0) {
+                /* A lack of any security providers should be
+                 * an "impossible" condition.  But if it occurs we print
+                 * to stderr instead of throwing in a static
+                 * initializer.
+                 */
+                System.err.println("Unable to configure ECDSA, no security providers present");
+            } else if (providers[0].getName().equals("SunPKCS11-NSS")) {
+                /* JcaPEMKeyConverter maintains an internal mapping of
+                 * algorithms identifies to string codes. If SunPKCS11-NSS
+                 * is the most preferred provider, reflection is used to
+                 * adjust that mapping to match the expectations of
+                 * SunPKCS11.
+                 */
+                Field fieldDefinition = JcaPEMKeyConverter.class.getDeclaredField("algorithms");
+                fieldDefinition.setAccessible(true);
+                Object fieldValue = fieldDefinition.get(null);
+                Method put = fieldValue.getClass().getDeclaredMethod("put", Object.class, Object.class);
+                put.invoke(fieldValue, X9ObjectIdentifiers.id_ecPublicKey, "EC");
+            }
+        } catch (ReflectiveOperationException e) {
+            System.err.println("SunPKCS11-NSS is preferred security provider, "
+                               + "but failed to enable for ECDSA via reflection");
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
On a reasonable public cloud container, SunPKCS11-NSS is roughly 50%
faster than BouncyCastle, making this reflection jungle gym
worthwhile.  If the reflection fails (lacking a logging framework) we
print to stderr and move on.

NOTE: This is bound to the internals of BouncyCastle, so trivial
upstream changes could break this class.

ref #9