### PR TITLE
remove extraneous httpclient from common module

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -46,11 +46,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${dependency.apache-httpclient.version}</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
While the *apache* module very much needs httpclient, the core module
does not, and should not.