### PR TITLE
prefer modern java.time classes over unsafe legacy ones

### DIFF
--- a/common/src/test/java/com/joyent/http/signature/SignerTest.java
+++ b/common/src/test/java/com/joyent/http/signature/SignerTest.java
@@ -15,7 +15,11 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 public abstract class SignerTest {
@@ -42,6 +46,31 @@ public abstract class SignerTest {
                 "testy", testKeyPair, now);
         final boolean verified = signer.verifyAuthorizationHeader(
                 testKeyPair, authzHeader, now);
+        Assert.assertTrue(verified, "Unable to verify signed authorization header");
+    }
+
+    @Test(dataProvider = "testData")
+    @SuppressWarnings("deprecation")
+    public void signHeaderFixedLegacyDate(String hash, String providerCode) {
+        final Signer signer = new Signer.Builder(testKeyPair).hash(hash).providerCode(providerCode).build();
+        final Date legacyDate = new Date(1_000_000_000L * 1000);
+        final String stringDate = "Sun, 9 Sep 2001 01:46:40 GMT";
+        final String authzHeader = signer.createAuthorizationHeader(
+                "testy", testKeyPair, legacyDate);
+        final boolean verified = signer.verifyAuthorizationHeader(
+                testKeyPair, authzHeader, stringDate);
+        Assert.assertTrue(verified, "Unable to verify signed authorization header");
+    }
+
+    @Test(dataProvider = "testData")
+    public void signHeaderDateTime(String hash, String providerCode) {
+        final Signer signer = new Signer.Builder(testKeyPair).hash(hash).providerCode(providerCode).build();
+        final ZonedDateTime dt = ZonedDateTime.ofInstant(Instant.ofEpochSecond(1_000_000_000L), ZoneOffset.UTC);
+        final String stringDate = "Sun, 9 Sep 2001 01:46:40 GMT";
+        final String authzHeader = signer.createAuthorizationHeader(
+                "testy", testKeyPair, dt);
+        final boolean verified = signer.verifyAuthorizationHeader(
+                testKeyPair, authzHeader, stringDate);
         Assert.assertTrue(verified, "Unable to verify signed authorization header");
     }
 

--- a/jaxrs-client/src/main/java/com/joyent/http/signature/jaxrs/client/SignedRequestClientRequestFilter.java
+++ b/jaxrs-client/src/main/java/com/joyent/http/signature/jaxrs/client/SignedRequestClientRequestFilter.java
@@ -19,7 +19,9 @@ import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.security.KeyPair;
-import java.util.Date;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
 
@@ -160,8 +162,8 @@ public class SignedRequestClientRequestFilter implements ClientRequestFilter {
     @Override
     public void filter(final ClientRequestContext requestContext) throws IOException {
         final MultivaluedMap<String, Object> headers = requestContext.getHeaders();
-        final Date now = new Date();
-        final String dateHeaderValue = Signer.DATE_FORMAT.format(now);
+        final ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        final String dateHeaderValue = DateTimeFormatter.RFC_1123_DATE_TIME.format(now);
         headers.add(DATE_HEADER_NAME, dateHeaderValue);
         final String authHeaderValue = signer.get().createAuthorizationHeader(
                 loginName,

--- a/microbench/src/main/java/com/joyent/http/signature/DefaultSignDateAsStringBenchmark.java
+++ b/microbench/src/main/java/com/joyent/http/signature/DefaultSignDateAsStringBenchmark.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.http.signature;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+
+import java.io.IOException;
+import java.security.KeyPair;
+
+
+@State(Scope.Benchmark)
+@SuppressWarnings({"checkstyle:javadocmethod", "checkstyle:javadoctype", "checkstyle:javadocvariable",
+            "checkstyle:magicnumber"})
+public class DefaultSignDateAsStringBenchmark  {
+
+    private KeyPair keyPair;
+    private String testKeyFingerprint;
+    private Signer signer;
+    private boolean firstSetup = true;
+
+    @Setup
+    public void setup() throws IOException {
+        testKeyFingerprint = SignerTestUtil.testKeyMd5Fingerprint("rsa_1024");
+        keyPair = SignerTestUtil.testKeyPair("rsa_1024");
+        signer = new Signer.Builder(keyPair).hash("SHA256").providerCode("stdlib").build();
+
+        if (firstSetup) {
+            System.out.println("\n#Signature-->Provider: " + signer.getSignature().getProvider().getName());
+            firstSetup = false;
+        }
+    }
+
+    @Benchmark
+    @Threads(1)
+    public String thread1() {
+        return signer.defaultSignDateAsString();
+    }
+
+    @Benchmark
+    @Threads(4)
+    public String thread4() {
+        return signer.defaultSignDateAsString();
+    }
+
+    @Threads(8)
+    public String thread8() {
+        return signer.defaultSignDateAsString();
+    }
+
+    @Benchmark
+    @Threads(64)
+    public String thread64() {
+        return signer.defaultSignDateAsString();
+    }
+
+}


### PR DESCRIPTION
Java 8 included JRS-310 which brought in modern date/time libraries.
The legacy java.util.Date is mutable(!), doesn't actually represent a
date(!!), and companion classes are not thead-safe.  In particular the
existing call to `SimpleDateFormat.format` was unsafe from multiple
threads, which left callers of Signer in perpetual risk of errors.

ref #34