### PR TITLE
Load KeyPair from Path with Password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - Utility methods for calculating MD5 fingerprints, calculating
    SHA256 fingerprints, and verifying OpenSSH's string format have
    been added.
+ - It is now possible to load a `KeyPair` from a `Path` or `File` in
+   combination with a passphrase.
 
 ### Changed
  - Methods that took an explicit fingerprint `String` now ignore it in

--- a/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
+++ b/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
@@ -64,6 +64,7 @@ public final class KeyPairLoader {
      * Read KeyPair from the specified file.
      *
      * @param keyFile The file containing the key
+     * @param password password associated with key
      *
      * @return public-private keypair object
      * @throws IOException If unable to read the private key from the file

--- a/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
+++ b/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
@@ -51,10 +51,24 @@ public final class KeyPairLoader {
      * Read KeyPair located at the specified path.
      *
      * @param keyPath The path to the key
+
      * @return public-private keypair object
      * @throws IOException If unable to read the private key from the file
      */
     public static KeyPair getKeyPair(final Path keyPath) throws IOException {
+        return getKeyPair(keyPath, null);
+    }
+
+    /**
+     * Read KeyPair located at the specified path.
+     *
+     * @param keyPath The path to the key
+     * @param password password associated with key
+
+     * @return public-private keypair object
+     * @throws IOException If unable to read the private key from the file
+     */
+    public static KeyPair getKeyPair(final Path keyPath, final char[] password) throws IOException {
         if (keyPath == null) {
             throw new FileNotFoundException("No key file path specified");
         }
@@ -70,7 +84,7 @@ public final class KeyPairLoader {
         }
 
         try (InputStream is = Files.newInputStream(keyPath)) {
-            return getKeyPair(is, null);
+            return getKeyPair(is, password);
         }
     }
 

--- a/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
+++ b/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
@@ -17,6 +17,7 @@ import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,6 +46,30 @@ public final class KeyPairLoader {
         new NssBridgeKeyConverter();
     {
         CONVERTER.setProvider("BC");
+    }
+
+    /**
+     * Read KeyPair from the specified file. Convenience method.
+     *
+     * @param keyFile The file containing the key
+     *
+     * @return public-private keypair object
+     * @throws IOException If unable to read the private key from the file
+     */
+    public static KeyPair getKeyPair(final File keyFile) throws IOException {
+        return getKeyPair(keyFile.toPath(), null);
+    }
+
+    /**
+     * Read KeyPair located at the specified path.
+     *
+     * @param keyFile The file containing the key
+     *
+     * @return public-private keypair object
+     * @throws IOException If unable to read the private key from the file
+     */
+    public static KeyPair getKeyPair(final File keyFile, final char[] password) throws IOException {
+        return getKeyPair(keyFile.toPath(), password);
     }
 
     /**

--- a/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
+++ b/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
@@ -49,7 +49,7 @@ public final class KeyPairLoader {
     }
 
     /**
-     * Read KeyPair from the specified file. Convenience method.
+     * Read KeyPair from the specified file.
      *
      * @param keyFile The file containing the key
      *
@@ -61,7 +61,7 @@ public final class KeyPairLoader {
     }
 
     /**
-     * Read KeyPair located at the specified path.
+     * Read KeyPair from the specified file.
      *
      * @param keyFile The file containing the key
      *

--- a/common/src/test/java/com/joyent/http/signature/KeyPairLoaderTest.java
+++ b/common/src/test/java/com/joyent/http/signature/KeyPairLoaderTest.java
@@ -1,0 +1,107 @@
+package com.joyent.http.signature;
+
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.testng.Assert;
+import org.testng.AssertJUnit;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+
+@Test
+public class KeyPairLoaderTest {
+
+    private static final String RSA_HEADER = "-----BEGIN RSA PRIVATE KEY-----";
+
+    public void willThrowOnNullInputs() {
+        Assert.assertThrows(() ->
+                KeyPairLoader.getKeyPair((String) null, null));
+        Assert.assertThrows(() ->
+                KeyPairLoader.getKeyPair((Path) null, null));
+    }
+
+    public void canLoadGeneratedBytesKeyPair() throws Exception {
+        final KeyPair keyPair = generateKeyPair();
+        final byte[] serializedKey = serializePrivateKey(keyPair, null);
+
+        Assert.assertTrue(new String(serializedKey, StandardCharsets.UTF_8).startsWith(RSA_HEADER));
+
+        final KeyPair loadedKeyPair = KeyPairLoader.getKeyPair(serializedKey, null);
+
+        compareKeyContents(keyPair, loadedKeyPair);
+    }
+
+    public void canLoadKeyPairFromFile() throws Exception {
+        final KeyPair keyPair = generateKeyPair();
+        final byte[] serializedKey = serializePrivateKey(keyPair, null);
+
+        final File keyFile = Files.createTempFile("private-key", "").toFile();
+        keyFile.deleteOnExit();
+        final FileOutputStream fos = new FileOutputStream(keyFile);
+        fos.write(serializedKey);
+
+        final KeyPair loadedKeyPair = KeyPairLoader.getKeyPair(keyFile.toPath());
+
+        compareKeyContents(keyPair, loadedKeyPair);
+    }
+
+    public void canLoadPasswordProtectedKeyBytes() throws Exception {
+        final KeyPair keyPair = generateKeyPair();
+        final String passphrase = "randompassword";
+        // final byte[] serializedKey = serializePrivateKey(keyPair, passphrase);
+        final byte[] serializedKey = serializePrivateKey(keyPair, passphrase);
+
+        final KeyPair loadedKeyPair = KeyPairLoader.getKeyPair(serializedKey, passphrase.toCharArray());
+
+        compareKeyContents(keyPair, loadedKeyPair);
+    }
+
+
+    private KeyPair generateKeyPair() throws NoSuchAlgorithmException {
+        final KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(1024);
+        return generator.generateKeyPair();
+    }
+
+    private byte[] serializePrivateKey(final KeyPair keyPair,
+                                       final String passphrase) throws Exception {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final JcaPEMWriter jcaPEMWriter = new JcaPEMWriter(new OutputStreamWriter(baos));
+
+        if (passphrase != null) {
+            throw new SkipException("java.lang.ClassCastException: org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo cannot be cast to org.bouncycastle.openssl.PEMKeyPair");
+
+            // final OutputEncryptor outputEncryptor =
+            //         new JceOpenSSLPKCS8EncryptorBuilder(PKCS8Generator.PBE_SHA1_3DES)
+            //                 .setPasssword(passphrase.toCharArray())
+            //                 .build();
+            //
+            // jcaPEMWriter.writeObject(new JcaPKCS8Generator(keyPair.getPrivate(), outputEncryptor));
+        } else {
+            jcaPEMWriter.writeObject(keyPair.getPrivate());
+        }
+
+        jcaPEMWriter.flush();
+        jcaPEMWriter.close();
+        return baos.toByteArray();
+    }
+
+    private void compareKeyContents(KeyPair expectedKeyPair, KeyPair actualKeyPair) {
+        AssertJUnit.assertArrayEquals(
+                expectedKeyPair.getPrivate().getEncoded(),
+                actualKeyPair.getPrivate().getEncoded());
+        AssertJUnit.assertArrayEquals(
+                expectedKeyPair.getPublic().getEncoded(),
+                actualKeyPair.getPublic().getEncoded());
+    }
+
+}

--- a/common/src/test/java/com/joyent/http/signature/KeyPairLoaderTest.java
+++ b/common/src/test/java/com/joyent/http/signature/KeyPairLoaderTest.java
@@ -86,6 +86,8 @@ public class KeyPairLoaderTest {
         compareKeyContents(keyPair, loadedKeyPair);
     }
 
+    // TEST UTILITY METHODS
+
     private KeyPair generateKeyPair() throws NoSuchAlgorithmException {
         final KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
         generator.initialize(1024);

--- a/common/src/test/java/com/joyent/http/signature/KeyPairLoaderTest.java
+++ b/common/src/test/java/com/joyent/http/signature/KeyPairLoaderTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
 
 @Test
 public class KeyPairLoaderTest {
@@ -56,8 +57,7 @@ public class KeyPairLoaderTest {
 
     public void canLoadPasswordProtectedKeyBytes() throws Exception {
         final KeyPair keyPair = generateKeyPair();
-        final String passphrase = "randompassword";
-        // final byte[] serializedKey = serializePrivateKey(keyPair, passphrase);
+        final String passphrase = UUID.randomUUID().toString();
         final byte[] serializedKey = serializePrivateKey(keyPair, passphrase);
 
         final KeyPair loadedKeyPair = KeyPairLoader.getKeyPair(serializedKey, passphrase.toCharArray());

--- a/common/src/test/resources/testng.xml
+++ b/common/src/test/resources/testng.xml
@@ -7,6 +7,7 @@
             <class name="com.joyent.http.signature.SignerECDSATest" />
             <class name="com.joyent.http.signature.SignerLegacyConstructorTest" />
             <class name="com.joyent.http.signature.SignerRSATest" />
+            <class name="com.joyent.http.signature.KeyPairLoaderTest" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
Resolves #36 

Make it possible to use a password in combination with a key path.

Recommendations on how to make the test cases more useful would be appreciated, all I could come up with was being able to load the full KeyPair from just the private key content.

Additional convenience methods were added to allow users to pass in a `File` object instead of having to call `f.toPath()` but I can remove those if there are any objections.