### PR TITLE
Undo reflective modification of SunPKCS11-NSS algorithms mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,8 @@ local.properties
 # TeXlipse plugin
 .texlipse
 
+# OS X
+.DS_Store
 
 ### Maven ###
 target/

--- a/common/src/main/java/com/joyent/http/signature/KeyLoadException.java
+++ b/common/src/main/java/com/joyent/http/signature/KeyLoadException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2017, Joyent, Inc. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.joyent.http.signature;
+
+/**
+ * Exception that can occur while loading a {@link java.security.KeyPair}.
+ *
+ * @since 4.0.4
+ * @author <a href="https://github.com/tjcelaya">Tomas Celayac</a>
+ */
+public class KeyLoadException extends HttpSignatureException {
+
+    /**
+     * Creates a new exception with the specified message.
+     * @param message Message to embed
+     */
+    public KeyLoadException(final String message) {
+        super(message);
+    }
+}

--- a/common/src/main/java/com/joyent/http/signature/KeyLoadException.java
+++ b/common/src/main/java/com/joyent/http/signature/KeyLoadException.java
@@ -15,6 +15,8 @@ package com.joyent.http.signature;
  */
 public class KeyLoadException extends HttpSignatureException {
 
+    private static final long serialVersionUID = 3842266217250311085L;
+
     /**
      * Creates a new exception with the specified message.
      * @param message Message to embed

--- a/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
+++ b/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
@@ -59,15 +59,20 @@ public final class KeyPairLoader {
     /**
      * Set of security providers users can request.
      */
-    @SuppressWarnings("checkstyle:JavaDocVariable")
+    @SuppressWarnings({"checkstyle:JavaDocVariable", "checkstyle:JavadocMethod"})
     public enum DesiredSecurityProvider {
-        PKCS11_NSS(PROVIDER_PKCS11_NSS),
-        BOUNCY_CASTLE(PROVIDER_BOUNCY_CASTLE);
+        BC(PROVIDER_BOUNCY_CASTLE),
+        NSS(PROVIDER_PKCS11_NSS);
 
         private final String providerCode;
 
          DesiredSecurityProvider(final String providerCode) {
             this.providerCode = providerCode;
+        }
+
+        @Override
+        public String toString() {
+             return providerCode;
         }
     }
 
@@ -246,13 +251,13 @@ public final class KeyPairLoader {
         }
 
         // throw if the user has specifically requested NSS and it is unavailable
-        if (provider != null && provider.equals(DesiredSecurityProvider.PKCS11_NSS) && CONVERTER_PKCS11_NSS == null) {
+        if (provider != null && provider.equals(DesiredSecurityProvider.NSS) && CONVERTER_PKCS11_NSS == null) {
             throw new KeyLoadException(PROVIDER_PKCS11_NSS + " provider requested but unavailable. "
                     + "Is java.security configured correctly?");
         }
 
         // Attempt to load with NSS if it is available and requested (or no provider was specified)
-        final boolean attemptPKCS11NSS = provider == null || provider.equals(DesiredSecurityProvider.PKCS11_NSS);
+        final boolean attemptPKCS11NSS = provider == null || provider.equals(DesiredSecurityProvider.NSS);
 
         if (CONVERTER_PKCS11_NSS != null && attemptPKCS11NSS) {
             return CONVERTER_PKCS11_NSS.getKeyPair(pemKeyPair);

--- a/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
+++ b/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
@@ -52,7 +52,7 @@ public final class KeyPairLoader {
     private static final JcaPEMKeyConverter CONVERTER_PKCS11_NSS;
 
     /**
-     * The key format converter to user when libnss is disabled (or BC is specifically requested).
+     * The key format converter to use when libnss is disabled (or BC is specifically requested).
      */
     private static final JcaPEMKeyConverter CONVERTER_BOUNCY_CASTLE;
 
@@ -229,6 +229,13 @@ public final class KeyPairLoader {
             throw new KeyLoadException("Unexpected PEM object loaded: " + pemObject.getClass().getCanonicalName());
         }
 
+        // throw if the user has specifically requested NSS and it is unavailable
+        if (provider != null && provider.equals(PROVIDER_PKCS11_NSS) && CONVERTER_PKCS11_NSS == null) {
+            throw new KeyLoadException(PROVIDER_PKCS11_NSS + " provider requested but unavailable. "
+                    + "Is java.security configured correctly?");
+        }
+
+        // Attempt to load with NSS, otherwise fallback to BC
         if (CONVERTER_PKCS11_NSS != null
                 && (provider == null || provider.equals(PROVIDER_PKCS11_NSS))) {
             return CONVERTER_PKCS11_NSS.getKeyPair(pemKeyPair);

--- a/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
+++ b/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
@@ -7,12 +7,12 @@
  */
 package com.joyent.http.signature;
 
-import com.joyent.http.signature.crypto.NssBridgeKeyConverter;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMDecryptorProvider;
 import org.bouncycastle.openssl.PEMEncryptedKeyPair;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
 
 import java.io.BufferedReader;
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyPair;
+import java.security.Provider;
 import java.security.Security;
 
 
@@ -35,18 +36,43 @@ import java.security.Security;
  */
 public final class KeyPairLoader {
 
+    /**
+     * Provider name for libnss.
+     */
+    public static final String PROVIDER_PKCS11_NSS = "SunPKCS11-NSS";
 
-    @SuppressWarnings("checkstyle:javadocmethod")
-    private KeyPairLoader() {
-    }
+    /**
+     * Provider name for Bouncy Castle.
+     */
+    public static final String PROVIDER_BOUNCY_CASTLE = "BC";
 
     /**
      * The key format converter to use when reading key pairs.
      */
-    private static final NssBridgeKeyConverter CONVERTER =
-        new NssBridgeKeyConverter();
-    {
-        CONVERTER.setProvider("BC");
+    private static final JcaPEMKeyConverter CONVERTER_PKCS11_NSS;
+
+    private static final JcaPEMKeyConverter CONVERTER_BOUNCY_CASTLE;
+
+    static {
+        final Provider providerPkcs11NSS = Security.getProvider(PROVIDER_PKCS11_NSS);
+
+        if (providerPkcs11NSS != null) {
+            CONVERTER_PKCS11_NSS = new JcaPEMKeyConverter().setProvider(PROVIDER_PKCS11_NSS);
+        } else {
+            CONVERTER_PKCS11_NSS = null;
+        }
+
+        final Provider providerBouncyCastle = Security.getProvider(PROVIDER_BOUNCY_CASTLE);
+
+        if (providerBouncyCastle == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+
+        CONVERTER_BOUNCY_CASTLE = new JcaPEMKeyConverter().setProvider(PROVIDER_BOUNCY_CASTLE);
+    }
+
+    @SuppressWarnings("checkstyle:javadocmethod")
+    private KeyPairLoader() {
     }
 
     /**
@@ -150,36 +176,62 @@ public final class KeyPairLoader {
     /**
      * Read KeyPair from an input stream, optionally using password.
      *
-     * @param is private key content as a stream
+     * @param is       private key content as a stream
      * @param password password associated with key
      * @return public/private keypair object
      * @throws IOException If unable to read the private key from the string
      */
     public static KeyPair getKeyPair(final InputStream is,
-                              final char[] password) throws IOException {
+                                     final char[] password) throws IOException {
+        return getKeyPair(is, password, null);
+    }
+
+    /**
+     * Read KeyPair from an input stream, optionally using password.
+     *
+     * @param is       private key content as a stream
+     * @param password password associated with key
+     * @param provider security provider to use when loading the key
+     * @return public/private keypair object
+     * @throws IOException If unable to read the private key from the string
+     */
+    public static KeyPair getKeyPair(final InputStream is,
+                                     final char[] password,
+                                     final String provider) throws IOException {
+        final Object pemObject;
         try (InputStreamReader isr = new InputStreamReader(is, StandardCharsets.US_ASCII);
              BufferedReader br = new BufferedReader(isr);
              PEMParser pemParser = new PEMParser(br)) {
 
-            if (password == null) {
-                Security.addProvider(new BouncyCastleProvider());
-                final Object object = pemParser.readObject();
-                return CONVERTER.getKeyPair((PEMKeyPair) object);
-            } else {
-                PEMDecryptorProvider decProv = new JcePEMDecryptorProviderBuilder().build(password);
-
-                Object object = pemParser.readObject();
-
-                final KeyPair kp;
-                if (object instanceof PEMEncryptedKeyPair) {
-                    kp = CONVERTER.getKeyPair(((PEMEncryptedKeyPair) object).decryptKeyPair(decProv));
-                } else {
-                    kp = CONVERTER.getKeyPair((PEMKeyPair) object);
-                }
-
-                return kp;
-            }
+            pemObject = pemParser.readObject();
         }
+
+        final PEMKeyPair pemKeyPair;
+
+        if (pemObject instanceof PEMEncryptedKeyPair) {
+            if (password == null) {
+                throw new KeyLoadException("Loaded key is encrypted but no password was supplied.");
+            }
+
+            final PEMDecryptorProvider decryptorProvider = new JcePEMDecryptorProviderBuilder().build(password);
+            final PEMEncryptedKeyPair encryptedPemObject = ((PEMEncryptedKeyPair) pemObject);
+            pemKeyPair = encryptedPemObject.decryptKeyPair(decryptorProvider);
+        } else if (pemObject instanceof PEMKeyPair) {
+            if (password != null) {
+                throw new KeyLoadException("Loaded key is not encrypted but a password was supplied.");
+            }
+
+            pemKeyPair = (PEMKeyPair) pemObject;
+        } else {
+            throw new KeyLoadException("Unexpected PEM object loaded: " + pemObject.getClass().getCanonicalName());
+        }
+
+        if (CONVERTER_PKCS11_NSS != null
+                && (provider == null || provider.equals(PROVIDER_PKCS11_NSS))) {
+            return CONVERTER_PKCS11_NSS.getKeyPair(pemKeyPair);
+        }
+
+        return CONVERTER_BOUNCY_CASTLE.getKeyPair(pemKeyPair);
     }
 
 }

--- a/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
+++ b/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
@@ -47,10 +47,13 @@ public final class KeyPairLoader {
     public static final String PROVIDER_BOUNCY_CASTLE = "BC";
 
     /**
-     * The key format converter to use when reading key pairs.
+     * The key format converter to use when reading key pairs and libnss is enabled (or specifically requested).
      */
     private static final JcaPEMKeyConverter CONVERTER_PKCS11_NSS;
 
+    /**
+     * The key format converter to user when libnss is disabled (or BC is specifically requested).
+     */
     private static final JcaPEMKeyConverter CONVERTER_BOUNCY_CASTLE;
 
     static {

--- a/common/src/main/java/com/joyent/http/signature/crypto/NssBridgeKeyConverter.java
+++ b/common/src/main/java/com/joyent/http/signature/crypto/NssBridgeKeyConverter.java
@@ -7,13 +7,7 @@
  */
 package com.joyent.http.signature.crypto;
 
-import org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.security.Provider;
-import java.security.Security;
 
 /**
  * There is an unfortunate naming discrepancy between BouncyCastle and
@@ -31,35 +25,6 @@ import java.security.Security;
  * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/guides/security/p11guide.html">PKCS#11 Reference Guide</a>
  * @see <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS">Network Security Services</a>
  */
+@Deprecated
 public class NssBridgeKeyConverter extends JcaPEMKeyConverter {
-
-    {
-        Provider[] providers = Security.getProviders();
-        try {
-            if (providers == null || providers.length == 0) {
-                /* A lack of any security providers should be
-                 * an "impossible" condition.  But if it occurs we print
-                 * to stderr instead of throwing in a static
-                 * initializer.
-                 */
-                System.err.println("Unable to configure ECDSA, no security providers present");
-            } else if (providers[0].getName().equals("SunPKCS11-NSS")) {
-                /* JcaPEMKeyConverter maintains an internal mapping of
-                 * algorithms identifies to string codes. If SunPKCS11-NSS
-                 * is the most preferred provider, reflection is used to
-                 * adjust that mapping to match the expectations of
-                 * SunPKCS11.
-                 */
-                Field fieldDefinition = JcaPEMKeyConverter.class.getDeclaredField("algorithms");
-                fieldDefinition.setAccessible(true);
-                Object fieldValue = fieldDefinition.get(null);
-                Method put = fieldValue.getClass().getDeclaredMethod("put", Object.class, Object.class);
-                put.invoke(fieldValue, X9ObjectIdentifiers.id_ecPublicKey, "EC");
-            }
-        } catch (ReflectiveOperationException e) {
-            System.err.println("SunPKCS11-NSS is preferred security provider, "
-                               + "but failed to enable for ECDSA via reflection");
-            e.printStackTrace();
-        }
-    }
 }

--- a/common/src/test/java/com/joyent/http/signature/KeyPairLoaderTest.java
+++ b/common/src/test/java/com/joyent/http/signature/KeyPairLoaderTest.java
@@ -1,5 +1,6 @@
 package com.joyent.http.signature;
 
+import com.joyent.http.signature.KeyPairLoader.DesiredSecurityProvider;
 import org.bouncycastle.openssl.PEMEncryptor;
 import org.bouncycastle.openssl.jcajce.JcaMiscPEMGenerator;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
@@ -140,7 +141,7 @@ public class KeyPairLoaderTest {
         Assert.assertTrue(new String(serializedKey, StandardCharsets.UTF_8).startsWith(RSA_HEADER));
 
         Assert.assertThrows(KeyLoadException.class, () ->
-                KeyPairLoader.getKeyPair(new ByteArrayInputStream(serializedKey), null, PROVIDER_PKCS11_NSS));
+                KeyPairLoader.getKeyPair(new ByteArrayInputStream(serializedKey), null, DesiredSecurityProvider.PKCS11_NSS));
     }
 
     // TEST UTILITY METHODS
@@ -181,8 +182,15 @@ public class KeyPairLoaderTest {
 
     private KeyPair loadTestKeyPair(final String resourcePath, final String provider) throws IOException {
         final KeyPair loadedKeyPair;
+        final DesiredSecurityProvider desiredProvider;
+        if (provider != null) {
+            desiredProvider = DesiredSecurityProvider.valueOf(provider);
+        } else {
+            desiredProvider = null;
+        }
+
         try (final InputStream inputKey = CLASS_LOADER.getResourceAsStream(resourcePath)) {
-            loadedKeyPair = KeyPairLoader.getKeyPair(inputKey, null, provider);
+            loadedKeyPair = KeyPairLoader.getKeyPair(inputKey, null, desiredProvider);
 
         }
         return loadedKeyPair;

--- a/common/src/test/java/com/joyent/http/signature/SignerTestUtil.java
+++ b/common/src/test/java/com/joyent/http/signature/SignerTestUtil.java
@@ -53,10 +53,14 @@ public class SignerTestUtil {
     }
 
     public static KeyPair testKeyPair(String keyId) throws IOException {
+        return testKeyPair(keyId, null);
+    }
+
+    public static KeyPair testKeyPair(String keyId, String provider) throws IOException {
         final ClassLoader loader = SignerTestUtil.class.getClassLoader();
 
         try (InputStream is = loader.getResourceAsStream(keys.get(keyId).resourcePath)) {
-            KeyPair classPathPair = KeyPairLoader.getKeyPair(is, null);
+            KeyPair classPathPair = KeyPairLoader.getKeyPair(is, null, provider);
             return classPathPair;
         }
     }

--- a/common/src/test/java/com/joyent/http/signature/SignerTestUtil.java
+++ b/common/src/test/java/com/joyent/http/signature/SignerTestUtil.java
@@ -13,7 +13,6 @@ import java.security.KeyPair;
 import java.util.HashMap;
 import java.util.Map;
 
-
 public class SignerTestUtil {
     @SuppressWarnings("serial")
     public static final Map<String,TestKeyResource> keys = new HashMap<String,TestKeyResource>() {{
@@ -53,14 +52,10 @@ public class SignerTestUtil {
     }
 
     public static KeyPair testKeyPair(String keyId) throws IOException {
-        return testKeyPair(keyId, null);
-    }
-
-    public static KeyPair testKeyPair(String keyId, String provider) throws IOException {
         final ClassLoader loader = SignerTestUtil.class.getClassLoader();
 
         try (InputStream is = loader.getResourceAsStream(keys.get(keyId).resourcePath)) {
-            KeyPair classPathPair = KeyPairLoader.getKeyPair(is, null, provider);
+            KeyPair classPathPair = KeyPairLoader.getKeyPair(is, null, null);
             return classPathPair;
         }
     }

--- a/microbench/src/main/java/com/joyent/http/signature/BenchmarkDSASigner.java
+++ b/microbench/src/main/java/com/joyent/http/signature/BenchmarkDSASigner.java
@@ -9,6 +9,9 @@ package com.joyent.http.signature;
 
 import org.openjdk.jmh.annotations.Param;
 
+import static com.joyent.http.signature.KeyPairLoader.PROVIDER_BOUNCY_CASTLE;
+import static com.joyent.http.signature.KeyPairLoader.PROVIDER_PKCS11_NSS;
+
 
 @SuppressWarnings({"checkstyle:javadocmethod", "checkstyle:javadoctype", "checkstyle:javadocvariable"})
 public class BenchmarkDSASigner extends BenchmarkSigner {
@@ -17,6 +20,9 @@ public class BenchmarkDSASigner extends BenchmarkSigner {
 
     @Param({"stdlib"})
     private String providerCode;
+
+    @Param({PROVIDER_PKCS11_NSS, PROVIDER_BOUNCY_CASTLE})
+    private String keyProviderCode;
 
     @Override
     public String getKeyCode() {

--- a/microbench/src/main/java/com/joyent/http/signature/BenchmarkECDSASigner.java
+++ b/microbench/src/main/java/com/joyent/http/signature/BenchmarkECDSASigner.java
@@ -9,6 +9,9 @@ package com.joyent.http.signature;
 
 import org.openjdk.jmh.annotations.Param;
 
+import static com.joyent.http.signature.KeyPairLoader.PROVIDER_BOUNCY_CASTLE;
+import static com.joyent.http.signature.KeyPairLoader.PROVIDER_PKCS11_NSS;
+
 
 @SuppressWarnings({"checkstyle:javadocmethod", "checkstyle:javadoctype", "checkstyle:javadocvariable"})
 public class BenchmarkECDSASigner extends BenchmarkSigner {
@@ -17,6 +20,9 @@ public class BenchmarkECDSASigner extends BenchmarkSigner {
 
     @Param({"stdlib"})
     private String providerCode;
+
+    @Param({PROVIDER_PKCS11_NSS, PROVIDER_BOUNCY_CASTLE})
+    private String keyProviderCode;
 
     @Override
     public String getKeyCode() {

--- a/microbench/src/main/java/com/joyent/http/signature/BenchmarkRSASigner.java
+++ b/microbench/src/main/java/com/joyent/http/signature/BenchmarkRSASigner.java
@@ -9,6 +9,9 @@ package com.joyent.http.signature;
 
 import org.openjdk.jmh.annotations.Param;
 
+import static com.joyent.http.signature.KeyPairLoader.PROVIDER_BOUNCY_CASTLE;
+import static com.joyent.http.signature.KeyPairLoader.PROVIDER_PKCS11_NSS;
+
 
 @SuppressWarnings({"checkstyle:javadocmethod", "checkstyle:javadoctype", "checkstyle:javadocvariable"})
 public class BenchmarkRSASigner extends BenchmarkSigner {
@@ -17,6 +20,9 @@ public class BenchmarkRSASigner extends BenchmarkSigner {
 
     @Param({"stdlib", "native.jnagmp"})
     private String providerCode;
+
+    @Param({PROVIDER_PKCS11_NSS, PROVIDER_BOUNCY_CASTLE})
+    private String keyProviderCode;
 
     @Override
     public String getKeyCode() {


### PR DESCRIPTION
There's a new KeyPairLoader#getKeyPair which accepts a provider name.

Still need to verify that this behaves the way we expect (i.e. performance improves when using an explicitly-PKCS11-NSS-loaded keypair and remains the same if the keypair is BC-loaded)