### PR TITLE
More helpful KeyPairLoader error messages

### DIFF
--- a/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
+++ b/common/src/main/java/com/joyent/http/signature/KeyPairLoader.java
@@ -161,6 +161,8 @@ public final class KeyPairLoader {
 
         try (InputStream is = Files.newInputStream(keyPath)) {
             return getKeyPair(is, password);
+        } catch (final KeyLoadException kle) {
+            throw new IOException("Unable to load private key at path: " + keyPath, kle);
         }
     }
 
@@ -246,6 +248,8 @@ public final class KeyPairLoader {
             }
 
             pemKeyPair = (PEMKeyPair) pemObject;
+        } else if (pemObject == null) {
+            throw new KeyLoadException("Failed to load PEM object, please verify the input is a private key");
         } else {
             throw new KeyLoadException("Unexpected PEM object loaded: " + pemObject.getClass().getCanonicalName());
         }


### PR DESCRIPTION
Resolves #50 and makes the exception messages more helpful. Is it accurate to say that `KeyPairLoader` expects only private keys as input?

The second test added (`willThrowUsefulExceptionsOnPublicKeyFile`) implies that a public key is just as useless as an empty file since they both cause `PEMParser#readObject` to return null.