### PR TITLE
Upgrade Dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.1.0] 
+
+### Changed
+ - [Upgraded dependencies to latest stable versions:](https://github.com/joyent/java-http-signature/commit/aa0ad5dd209b86129dfe56e22553054056e7b3bb)
+        - HTTP Signatures dependency: 4.0.9 → 4.0.10
+        - BouncyCastle: 1.61 → 1.64
+        - Apache HttpClient: 4.5.7 → 4.5.11
+        - Google HttpClient: 1.28.0 → 1.32.1
+        - Jersey-Client 2.27 → 2.30.1
+        - Arquillian 1.4.0.Final → 1.6.0.Final
+        - Arquillian-TestNG 1.4.0.Final → 1.6.0.Final
+        - Slfj 1.7.25 → 1.7.30
+        - Checkstyle 8.16 → 8.30
+        - Commons-Codec 1.11 → 1.13
+ - Upgraded maven and maven-plugin dependencies.
+ - Added checkstyle warnings to [HttpSignatureAuthScheme.java](https://github.com/joyent/java-http-signature/blob/master/apache-http-client/src/main/java/com/joyent/http/signature/apache/httpclient/HttpSignatureAuthScheme.java), 
+   [HttpSignatureConfigurator.java](https://github.com/joyent/java-http-signature/blob/master/apache-http-client/src/main/java/com/joyent/http/signature/apache/httpclient/HttpSignatureConfigurator.java) and fixed checkstyle errors.
+
 ## [4.0.10] - 2019-02-27
 
 ### Changed
@@ -9,7 +27,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
  - [Upgrade Apache-Http-Client Dependency](https://github.com/joyent/java-http-signature/commit/9ee3137ac7fdc518f5136ee16a3e8161619461f9)
  - [Upgraded BC Version To 1.61](https://github.com/joyent/java-http-signature/commit/1e72d58f2b05adc7e401ce29cea02233c4bdd725)
  
-## [4.0.9] - 2019-01-15
+ ## [4.0.9] - 2019-01-15
 
 ### Changed
  - Upgraded dependency versions.

--- a/apache-http-client/src/main/java/com/joyent/http/signature/apache/httpclient/HttpSignatureAuthScheme.java
+++ b/apache-http-client/src/main/java/com/joyent/http/signature/apache/httpclient/HttpSignatureAuthScheme.java
@@ -33,7 +33,8 @@ import java.util.function.Function;
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  * @since 1.0.0
  */
-@SuppressWarnings("deprecation")
+@SuppressWarnings({"deprecation", "checkstyle:javadocmethod", "checkstyle:javadoctype",
+        "checkstyle:javadocvariable"})
 public class HttpSignatureAuthScheme implements ContextAwareAuthScheme {
     /**
      * Name of authentication scheme.

--- a/apache-http-client/src/main/java/com/joyent/http/signature/apache/httpclient/HttpSignatureConfigurator.java
+++ b/apache-http-client/src/main/java/com/joyent/http/signature/apache/httpclient/HttpSignatureConfigurator.java
@@ -22,6 +22,8 @@ import java.security.KeyPair;
  * @author <a href="https://github.com/dekobon">Elijah Zupancic</a>
  * @since 2.0.5
  */
+@SuppressWarnings({"checkstyle:javadocmethod", "checkstyle:javadoctype",
+        "checkstyle:javadocvariable", "unused"})
 public class HttpSignatureConfigurator {
     /**
      * Public/private keypair object used to sign HTTP requests.

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -42,6 +42,11 @@
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sf.net/config_sizes.html -->
     <module name="FileLength"/>
+    <module name="LineLength">
+        <property name="max" value="120" />
+        <property name="tabWidth" value="4" />
+        <property name="ignorePattern" value="^.*\*.*@see.+$" />
+    </module>
 
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->
@@ -69,13 +74,12 @@
         <module name="SuppressWarningsHolder" />
 
         <!-- Checks for Javadoc comments.                     -->
-        <!-- See http://checkstyle.sf.net/config_javadoc.html -->
-        <module name="JavadocMethod">
-            <property name="allowMissingPropertyJavadoc" value="true" />
-        </module>
-        <module name="JavadocType" />
+        <!-- See https://checkstyle.org/config_javadoc.html -->
+        <module name="InvalidJavadocPosition"/>
+        <module name="JavadocMethod"/>
+        <module name="JavadocType"/>
         <module name="JavadocVariable"/>
-        <module name="JavadocStyle" />
+        <module name="JavadocStyle"/>
 
         <!-- Checks for Naming Conventions.                  -->
         <!-- See http://checkstyle.sf.net/config_naming.html -->
@@ -101,12 +105,7 @@
         <module name="UnusedImports"/>
 
         <!-- Checks for Size Violations.                    -->
-        <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="LineLength">
-            <property name="max" value="120" />
-            <property name="tabWidth" value="4" />
-            <property name="ignorePattern" value="^.*\*.*@see.+$" />
-        </module>
+        <!-- See https://checkstyle.org/config_sizes.html -->
         <module name="MethodLength" />
         <module name="ParameterNumber" />
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -20,9 +20,9 @@
 
     <properties>
         <!-- Dependency versions -->
-        <dependency.bouncycastle.version>1.61</dependency.bouncycastle.version>
+        <dependency.bouncycastle.version>1.64</dependency.bouncycastle.version>
         <dependency.jnagmp.version>2.1.0</dependency.jnagmp.version>
-        <dependency.commons-codec.version>1.11</dependency.commons-codec.version>
+        <dependency.commons-codec.version>1.13</dependency.commons-codec.version>
     </properties>
 
     <dependencies>

--- a/common/src/main/java/com/joyent/http/signature/Signer.java
+++ b/common/src/main/java/com/joyent/http/signature/Signer.java
@@ -112,7 +112,7 @@ public class Signer {
         httpHeaderAlgorithm = builder.httpHeaderAlgorithm();
         if (provider == null) {
             try {
-                signature = Signature.getInstance(builder.javaStandardName(provider));
+                signature = Signature.getInstance(builder.javaStandardName(null));
             } catch (NoSuchAlgorithmException nsae) {
                 throw new CryptoException(nsae);
             }
@@ -215,6 +215,7 @@ public class Signer {
      * @param keyPair public/private keypair
      * @return value to Authorization header
      */
+    @SuppressWarnings("unused")
     public String createAuthorizationHeader(final String login,
                                             final KeyPair keyPair) {
         return createAuthorizationHeader(login, keyPair, defaultSignDateAsString());
@@ -652,15 +653,17 @@ public class Signer {
              * @return New {@code SigningAlgorithmHelper} instance.
             */
             public static SigningAlgorithmHelper create(final String algorithm) {
-                if (algorithm.equals("RSA")) {
-                    return new RsaHelper();
-                } else if (algorithm.equals("DSA")) {
-                    return new DsaHelper();
+                switch (algorithm) {
+                    case "RSA":
+                        return new RsaHelper();
+                    case "DSA":
+                        return new DsaHelper();
                     // See NssBridgeKeyConverter on the two names
-                } else if (algorithm.equals("ECDSA") || algorithm.equals("EC")) {
-                    return new EcdsaHelper();
-                } else {
-                    throw new IllegalArgumentException("invalid signing algorithm: " + algorithm);
+                    case "ECDSA":
+                    case "EC":
+                        return new EcdsaHelper();
+                    default:
+                        throw new IllegalArgumentException("invalid signing algorithm: " + algorithm);
                 }
             }
 

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <!-- Dependency versions -->
         <dependency.http-signature-common.version>4.0.11-SNAPSHOT</dependency.http-signature-common.version>
-        <dependency.google-http-client.version>1.28.0</dependency.google-http-client.version>
+        <dependency.google-http-client.version>1.32.1</dependency.google-http-client.version>
     </properties>
 
     <dependencies>

--- a/jaxrs-client/pom.xml
+++ b/jaxrs-client/pom.xml
@@ -20,14 +20,14 @@
 
     <properties>
         <!-- Dependency versions -->
-        <dependency.arquillian.version>1.4.0.Final</dependency.arquillian.version>
+        <dependency.arquillian.version>1.5.0.Final</dependency.arquillian.version>
         <dependency.arquillian-glassfish-embedded-3.1.version>1.0.2</dependency.arquillian-glassfish-embedded-3.1.version>
         <dependency.http-signature-common.version>4.0.11-SNAPSHOT</dependency.http-signature-common.version>
-        <dependency.javaee.version>8.0</dependency.javaee.version>
+        <dependency.javaee.version>8.0.1</dependency.javaee.version>
         <dependency.jax-rs-api.version>2.1.1</dependency.jax-rs-api.version>
-        <dependency.jersey-client.version>2.27</dependency.jersey-client.version>
-        <dependency.payara-embedded-web.version>5.184</dependency.payara-embedded-web.version>
-        <dependency.arquillian-testng-container>1.4.1.Final</dependency.arquillian-testng-container>
+        <dependency.jersey-client.version>2.29.1</dependency.jersey-client.version>
+        <dependency.payara-embedded-web.version>5.193.1</dependency.payara-embedded-web.version>
+        <dependency.arquillian-testng-container>1.5.0.Final</dependency.arquillian-testng-container>
     </properties>
 
     <dependencyManagement>

--- a/jaxrs-client/pom.xml
+++ b/jaxrs-client/pom.xml
@@ -20,14 +20,14 @@
 
     <properties>
         <!-- Dependency versions -->
-        <dependency.arquillian.version>1.5.0.Final</dependency.arquillian.version>
+        <dependency.arquillian.version>1.6.0.Final</dependency.arquillian.version>
         <dependency.arquillian-glassfish-embedded-3.1.version>1.0.2</dependency.arquillian-glassfish-embedded-3.1.version>
         <dependency.http-signature-common.version>4.0.11-SNAPSHOT</dependency.http-signature-common.version>
         <dependency.javaee.version>8.0.1</dependency.javaee.version>
         <dependency.jax-rs-api.version>2.1.1</dependency.jax-rs-api.version>
-        <dependency.jersey-client.version>2.29.1</dependency.jersey-client.version>
-        <dependency.payara-embedded-web.version>5.193.1</dependency.payara-embedded-web.version>
-        <dependency.arquillian-testng-container>1.5.0.Final</dependency.arquillian-testng-container>
+        <dependency.jersey-client.version>2.30.1</dependency.jersey-client.version>
+        <dependency.payara-embedded-web.version>5.201</dependency.payara-embedded-web.version>
+        <dependency.arquillian-testng-container>1.6.0.Final</dependency.arquillian-testng-container>
     </properties>
 
     <dependencyManagement>

--- a/jaxrs-client/src/test/java/com/joyent/http/signature/jaxrs/client/SignedRequestClientRequestFilterIT.java
+++ b/jaxrs-client/src/test/java/com/joyent/http/signature/jaxrs/client/SignedRequestClientRequestFilterIT.java
@@ -127,7 +127,6 @@ public class SignedRequestClientRequestFilterIT extends Arquillian {
         }
 
         Assert.assertNotNull(response);
-        Assert.assertNotNull(response.getStatus());
         Assert.assertEquals(response.getStatus(), 200);
         logger.debug("response status code: {}", response.getStatus());
         Assert.assertNotNull(response.getMediaType());
@@ -161,6 +160,4 @@ public class SignedRequestClientRequestFilterIT extends Arquillian {
                         && authorizationString.contains("signature=")
         );
     }
-
-
 }

--- a/microbench/src/main/java/com/joyent/http/signature/BenchmarkSigner.java
+++ b/microbench/src/main/java/com/joyent/http/signature/BenchmarkSigner.java
@@ -88,8 +88,7 @@ public abstract class BenchmarkSigner {
     }
 
     protected String signHeader(final String now) {
-        String authzHeader = signer.createAuthorizationHeader("bench", keyPair, now);
-        return authzHeader;
+        return signer.createAuthorizationHeader("bench", keyPair, now);
     }
 
     protected boolean verifyHeader(final String ts, final String header) {

--- a/pom.xml
+++ b/pom.xml
@@ -95,36 +95,36 @@
         <surefire.forkCount>1</surefire.forkCount>
         <surefire.useSystemClassLoader>true</surefire.useSystemClassLoader>
         <!-- Dependency versions -->
-        <dependency.checkstyle.version>8.16</dependency.checkstyle.version>
-        <dependency.apache-httpclient.version>4.5.7</dependency.apache-httpclient.version>
-        <dependency.testng.version>6.14.3</dependency.testng.version>
-        <dependency.slfj.version>1.7.25</dependency.slfj.version>
+        <dependency.checkstyle.version>8.30</dependency.checkstyle.version>
+        <dependency.apache-httpclient.version>4.5.11</dependency.apache-httpclient.version>
+        <dependency.testng.version>7.1.0</dependency.testng.version>
+        <dependency.slfj.version>1.7.30</dependency.slfj.version>
         <dependency.logback.version>1.2.3</dependency.logback.version>
         <!-- Plugin versions -->
-        <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
-        <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
-        <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
-        <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
-        <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-        <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
-        <maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>
+        <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
+        <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
+        <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
+        <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
+        <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-        <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
-        <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
-        <maven-jarsigner-plugin.version>1.4</maven-jarsigner-plugin.version>
-        <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
-        <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
+        <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
+        <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
+        <maven-jarsigner-plugin.version>3.0.0</maven-jarsigner-plugin.version>
+        <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
+        <maven-jxr-plugin.version>3.0.0</maven-jxr-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-        <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
-        <maven-shade-plugin.version>2.4.2</maven-shade-plugin.version>
-        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
-        <maven-jacoco-plugin.version>0.8.1</maven-jacoco-plugin.version>
-        <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
+        <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
+        <maven-shade-plugin.version>3.2.2</maven-shade-plugin.version>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <maven-jacoco-plugin.version>0.8.5</maven-jacoco-plugin.version>
+        <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
 
         <!-- Maven plugin dependency versions -->
-        <maven-plexus-compiler-javac-errorprone.version>2.8.5</maven-plexus-compiler-javac-errorprone.version>
-        <maven-error-prone-core.version>2.3.2</maven-error-prone-core.version>
+        <maven-plexus-compiler-javac-errorprone.version>2.8.6</maven-plexus-compiler-javac-errorprone.version>
+        <maven-error-prone-core.version>2.3.4</maven-error-prone-core.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <!-- Dependency versions -->
         <dependency.checkstyle.version>8.30</dependency.checkstyle.version>
         <dependency.apache-httpclient.version>4.5.11</dependency.apache-httpclient.version>
-        <dependency.testng.version>7.1.0</dependency.testng.version>
+        <dependency.testng.version>6.14.3</dependency.testng.version>
         <dependency.slfj.version>1.7.30</dependency.slfj.version>
         <dependency.logback.version>1.2.3</dependency.logback.version>
         <!-- Plugin versions -->


### PR DESCRIPTION
**Changes Introduced:**

- [Upgraded dependencies to latest stable versions:](https://github.com/joyent/java-http-signature/commit/aa0ad5dd209b86129dfe56e22553054056e7b3bb)
        - HTTP Signatures dependency: 4.0.9 → 4.0.10
        - BouncyCastle: 1.61 → 1.64
        - Apache HttpClient: 4.5.7 → 4.5.11
        - Google HttpClient: 1.28.0 → 1.32.1
        - Jersey-Client 2.27 → 2.30.1
        - Arquillian 1.4.0.Final → 1.6.0.Final
        - Arquillian-TestNG 1.4.0.Final → 1.6.0.Final
        - Slfj 1.7.25 → 1.7.30
        - Checkstyle 8.16 → 8.30
        - Commons-Codec 1.11 → 1.13
 - Upgraded maven and maven-plugin dependencies.
 - Added checkstyle warnings to [HttpSignatureAuthScheme.java](https://github.com/joyent/java-http-signature/blob/master/apache-http-client/src/main/java/com/joyent/http/signature/apache/httpclient/HttpSignatureAuthScheme.java), 
   [HttpSignatureConfigurator.java](https://github.com/joyent/java-http-signature/blob/master/apache-http-client/src/main/java/com/joyent/http/signature/apache/httpclient/HttpSignatureConfigurator.java) and fixed checkstyle errors.