### PR TITLE
Dependency upgrade for jnagmp from 2.1.0 -> 3.0.0

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,7 +21,7 @@
     <properties>
         <!-- Dependency versions -->
         <dependency.bouncycastle.version>1.64</dependency.bouncycastle.version>
-        <dependency.jnagmp.version>2.1.0</dependency.jnagmp.version>
+        <dependency.jnagmp.version>3.0.0</dependency.jnagmp.version>
         <dependency.commons-codec.version>1.13</dependency.commons-codec.version>
     </properties>
 


### PR DESCRIPTION
Upgrading dependency for `jnagmp` in the java-http-signature project since the java-client is undergoing a dependency upgrade. This change is made to avoid a dependency convergence problem for the [java-manta](https://github.com/joyent/java-manta).