### PR TITLE
Release java-http-signature-4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [4.1.0] 
+## [4.1.1] - 2020-03-23
+
+### Changed
+- [Dependency upgrade for jnagmp from 2.1.0 -> 3.0.0](https://github.com/joyent/java-http-signature/pull/60)
+
+## [4.1.0] - 2020-03-03
 
 ### Changed
  - [Upgraded dependencies to latest stable versions:](https://github.com/joyent/java-http-signature/commit/aa0ad5dd209b86129dfe56e22553054056e7b3bb)

--- a/apache-http-client/pom.xml
+++ b/apache-http-client/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>java-http-signature</artifactId>
         <groupId>com.joyent.http-signature</groupId>
-        <version>4.1.1</version>
+        <version>4.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>apache-http-client-signature</artifactId>
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- Dependency versions -->
-        <dependency.http-signature-common.version>4.1.1</dependency.http-signature-common.version>
+        <dependency.http-signature-common.version>4.1.2-SNAPSHOT</dependency.http-signature-common.version>
     </properties>
 
     <dependencies>

--- a/apache-http-client/pom.xml
+++ b/apache-http-client/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>java-http-signature</artifactId>
         <groupId>com.joyent.http-signature</groupId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.1.1</version>
     </parent>
 
     <artifactId>apache-http-client-signature</artifactId>
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- Dependency versions -->
-        <dependency.http-signature-common.version>4.1.1-SNAPSHOT</dependency.http-signature-common.version>
+        <dependency.http-signature-common.version>4.1.1</dependency.http-signature-common.version>
     </properties>
 
     <dependencies>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>java-http-signature</artifactId>
         <groupId>com.joyent.http-signature</groupId>
-        <version>4.1.1</version>
+        <version>4.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>http-signature-common</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>java-http-signature</artifactId>
         <groupId>com.joyent.http-signature</groupId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.1.1</version>
     </parent>
 
     <artifactId>http-signature-common</artifactId>

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>java-http-signature</artifactId>
         <groupId>com.joyent.http-signature</groupId>
-        <version>4.1.1</version>
+        <version>4.1.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -19,7 +19,7 @@
 
     <properties>
         <!-- Dependency versions -->
-        <dependency.http-signature-common.version>4.1.1</dependency.http-signature-common.version>
+        <dependency.http-signature-common.version>4.1.2-SNAPSHOT</dependency.http-signature-common.version>
         <dependency.google-http-client.version>1.32.1</dependency.google-http-client.version>
     </properties>
 

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>java-http-signature</artifactId>
         <groupId>com.joyent.http-signature</groupId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.1.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -19,7 +19,7 @@
 
     <properties>
         <!-- Dependency versions -->
-        <dependency.http-signature-common.version>4.1.1-SNAPSHOT</dependency.http-signature-common.version>
+        <dependency.http-signature-common.version>4.1.1</dependency.http-signature-common.version>
         <dependency.google-http-client.version>1.32.1</dependency.google-http-client.version>
     </properties>
 

--- a/jaxrs-client/pom.xml
+++ b/jaxrs-client/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>java-http-signature</artifactId>
         <groupId>com.joyent.http-signature</groupId>
-        <version>4.1.1</version>
+        <version>4.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>jaxrs-client-signature</artifactId>
@@ -22,7 +22,7 @@
         <!-- Dependency versions -->
         <dependency.arquillian.version>1.6.0.Final</dependency.arquillian.version>
         <dependency.arquillian-glassfish-embedded-3.1.version>1.0.2</dependency.arquillian-glassfish-embedded-3.1.version>
-        <dependency.http-signature-common.version>4.1.1</dependency.http-signature-common.version>
+        <dependency.http-signature-common.version>4.1.2-SNAPSHOT</dependency.http-signature-common.version>
         <dependency.javaee.version>8.0.1</dependency.javaee.version>
         <dependency.jax-rs-api.version>2.1.1</dependency.jax-rs-api.version>
         <dependency.jersey-client.version>2.30.1</dependency.jersey-client.version>

--- a/jaxrs-client/pom.xml
+++ b/jaxrs-client/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>java-http-signature</artifactId>
         <groupId>com.joyent.http-signature</groupId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.1.1</version>
     </parent>
 
     <artifactId>jaxrs-client-signature</artifactId>
@@ -22,7 +22,7 @@
         <!-- Dependency versions -->
         <dependency.arquillian.version>1.6.0.Final</dependency.arquillian.version>
         <dependency.arquillian-glassfish-embedded-3.1.version>1.0.2</dependency.arquillian-glassfish-embedded-3.1.version>
-        <dependency.http-signature-common.version>4.1.1-SNAPSHOT</dependency.http-signature-common.version>
+        <dependency.http-signature-common.version>4.1.1</dependency.http-signature-common.version>
         <dependency.javaee.version>8.0.1</dependency.javaee.version>
         <dependency.jax-rs-api.version>2.1.1</dependency.jax-rs-api.version>
         <dependency.jersey-client.version>2.30.1</dependency.jersey-client.version>

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -12,7 +12,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     <parent>
         <artifactId>java-http-signature</artifactId>
         <groupId>com.joyent.http-signature</groupId>
-        <version>4.1.1</version>
+        <version>4.1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>microbench</artifactId>
@@ -20,7 +20,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
     <properties>
         <!-- Dependency versions -->
-        <dependency.http-signature-common.version>4.1.1</dependency.http-signature-common.version>
+        <dependency.http-signature-common.version>4.1.2-SNAPSHOT</dependency.http-signature-common.version>
         <dependency.jmh.version>1.21</dependency.jmh.version>
         <uberjar.name>benchmarks</uberjar.name>
     </properties>

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -12,7 +12,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     <parent>
         <artifactId>java-http-signature</artifactId>
         <groupId>com.joyent.http-signature</groupId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.1.1</version>
     </parent>
 
     <artifactId>microbench</artifactId>
@@ -20,7 +20,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
     <properties>
         <!-- Dependency versions -->
-        <dependency.http-signature-common.version>4.1.1-SNAPSHOT</dependency.http-signature-common.version>
+        <dependency.http-signature-common.version>4.1.1</dependency.http-signature-common.version>
         <dependency.jmh.version>1.21</dependency.jmh.version>
         <uberjar.name>benchmarks</uberjar.name>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.joyent.http-signature</groupId>
     <artifactId>java-http-signature</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.1.1</version>
     <packaging>pom</packaging>
 
     <name>java-http-signature</name>
@@ -67,7 +67,7 @@
         <connection>scm:git:git://github.com/joyent/java-http-signature.git</connection>
         <developerConnection>scm:git:git://github.com/joyent/java-http-signature.git</developerConnection>
         <url>git@github.com:joyent/java-http-signature.git</url>
-        <tag>HEAD</tag>
+        <tag>java-http-signature-4.1.1</tag>
     </scm>
     <issueManagement>
         <system>github.com</system>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.joyent.http-signature</groupId>
     <artifactId>java-http-signature</artifactId>
-    <version>4.1.1</version>
+    <version>4.1.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>java-http-signature</name>
@@ -67,7 +67,7 @@
         <connection>scm:git:git://github.com/joyent/java-http-signature.git</connection>
         <developerConnection>scm:git:git://github.com/joyent/java-http-signature.git</developerConnection>
         <url>git@github.com:joyent/java-http-signature.git</url>
-        <tag>java-http-signature-4.1.1</tag>
+        <tag>HEAD</tag>
     </scm>
     <issueManagement>
         <system>github.com</system>


### PR DESCRIPTION
Working branch set to track release, documentation etc. for next iteration of java-http-signature (`4.1.1`)