### PR TITLE
Dependency upgrade for BC, Checkstyle & Codec libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.1.2]
+
+### Changed 
+- [Dependency upgrade for BC, Checkstyle & Codec libraries](https://github.com/joyent/java-http-signature/pull/62)
+        - BouncyCastle: 1.64 → 1.65
+        - Commons-Codec: 1.13 → 1.14
+        - Checkstyle: 8.30 → 8.3
+
 ## [4.1.1] - 2020-03-23
 
 ### Changed

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -20,9 +20,9 @@
 
     <properties>
         <!-- Dependency versions -->
-        <dependency.bouncycastle.version>1.64</dependency.bouncycastle.version>
+        <dependency.bouncycastle.version>1.65</dependency.bouncycastle.version>
         <dependency.jnagmp.version>3.0.0</dependency.jnagmp.version>
-        <dependency.commons-codec.version>1.13</dependency.commons-codec.version>
+        <dependency.commons-codec.version>1.14</dependency.commons-codec.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <surefire.forkCount>1</surefire.forkCount>
         <surefire.useSystemClassLoader>true</surefire.useSystemClassLoader>
         <!-- Dependency versions -->
-        <dependency.checkstyle.version>8.30</dependency.checkstyle.version>
+        <dependency.checkstyle.version>8.31</dependency.checkstyle.version>
         <dependency.apache-httpclient.version>4.5.11</dependency.apache-httpclient.version>
         <dependency.testng.version>6.14.3</dependency.testng.version>
         <dependency.slfj.version>1.7.30</dependency.slfj.version>


### PR DESCRIPTION
Dependency Upgrade:
        -  BouncyCastle: 1.64 → 1.65
        - Commons-Codec: 1.13 → 1.14
        - Checkstyle: 8.30 → 8.31

Latest [release updates](https://www.bouncycastle.org/releasenotes.html) on `BouncyCastle` which is one of our encryption-providers in java-manta wrt Client Side Encryption. 